### PR TITLE
Adding Martin Fowler's Blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -191,5 +191,18 @@
             "Company Stories",
             "DevOps"
         ]
+    ],
+    "martinfowler": [
+        "https://martinfowler.com/"
+        [
+            "Architecture",
+            "Refactoring",
+            "Agile",
+            "Delivery",
+            "Microservices",
+            "Data",
+            "Testing",
+            "DSL"
+        ]
     ]
 }


### PR DESCRIPTION
https://martinfowler.com/ is a very renowned blog on software development according to https://hackbrightacademy.com/blog/software-engineering-blogs/